### PR TITLE
fix: use correct path to download models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ build
 *.log*
 bun.lock
 
+cache
 mox_store.db*
 email_store.db*

--- a/src/main/services/email/embedding.ts
+++ b/src/main/services/email/embedding.ts
@@ -1,15 +1,28 @@
 import { pipeline, type FeatureExtractionPipeline } from '@huggingface/transformers'
 import { cleanHtml } from '../utils'
+import path from 'path'
+import { app } from 'electron'
 
 class EmbeddingService {
   #extractor: FeatureExtractionPipeline | null = null
+
+  private get cacheDir(): string {
+    if (process.env.NODE_ENV === 'development') {
+      return path.join(process.cwd(), 'cache', 'transformers')
+    }
+
+    return path.join(app.getPath('userData'), 'mox', 'cache', 'transformers')
+  }
 
   async #getExtractor(): Promise<FeatureExtractionPipeline> {
     if (this.#extractor === null) {
       try {
         this.#extractor = await pipeline<'feature-extraction'>(
           'feature-extraction',
-          'Xenova/all-MiniLM-L6-v2'
+          'Xenova/all-MiniLM-L6-v2',
+          {
+            cache_dir: this.cacheDir
+          }
         )
       } catch (error) {
         console.error('Failed to initialize embedding model:', error)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Sets cache directory for model downloads in `EmbeddingService` based on environment in `embedding.ts`.
> 
>   - **Behavior**:
>     - Sets cache directory for model downloads in `EmbeddingService` based on environment.
>     - Uses `process.cwd()` for development and `app.getPath('userData')` for production.
>   - **Functions**:
>     - Adds `cacheDir` getter in `EmbeddingService` to determine cache path.
>     - Updates `#getExtractor()` to use `cacheDir` for `pipeline` cache.
>   - **Imports**:
>     - Adds `path` and `app` imports in `embedding.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=usemox%2Fmox&utm_source=github&utm_medium=referral)<sup> for e602e479dc859f9300f9b840a7035d06044d38c0. You can [customize](https://app.ellipsis.dev/usemox/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->