### PR TITLE
feat: cc and bcc in compose

### DIFF
--- a/src/renderer/src/components/inbox/recipients.tsx
+++ b/src/renderer/src/components/inbox/recipients.tsx
@@ -1,19 +1,80 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { cn } from '@renderer/lib/utils'
-import { composeStore } from '@renderer/stores/compose'
+import { composeStore, RecipientType } from '@renderer/stores/compose'
 import { Badge } from '@renderer/components/ui/badge'
-import { AutoComplete } from '@renderer/components/ui/autocomplete'
+import { AutoComplete, AutoCompleteItem } from '@renderer/components/ui/autocomplete'
 import { XIcon } from '@renderer/components/icons/x'
 import { EmailComposerProps, INPUT_STYLE } from './compose'
 import { observer } from 'mobx-react-lite'
 import { contactsStore } from '@renderer/stores/contacts'
+import { Button } from '../ui/button'
+
+interface RecipientInputProps {
+  composeId: string
+  recipientType: RecipientType
+  placeholder: string
+  contacts: AutoCompleteItem<string>[]
+  isLoading: boolean
+  handleRecipientSelect: (value: string, type: RecipientType) => void
+  handleRemoveRecipient: (email: string) => void
+  fetchContacts: (searchQuery: string) => Promise<void>
+}
+
+const RecipientInput = observer(
+  ({
+    composeId,
+    recipientType,
+    placeholder,
+    contacts,
+    isLoading,
+    handleRecipientSelect,
+    handleRemoveRecipient,
+    fetchContacts
+  }: RecipientInputProps) => {
+    const compose = composeStore.getCompose(composeId)
+    if (!compose) return null
+
+    const recipients = Array.from(compose.recipients.entries()).filter(
+      ([, type]) => type === recipientType
+    )
+
+    return (
+      <div className="inline-flex flex-wrap items-center gap-2 w-full">
+        {recipients.map(([email]) => (
+          <Badge
+            key={`${recipientType}-${email}`}
+            variant="secondary"
+            className="flex-none flex items-center gap-1 px-2 py-1 rounded-sm"
+          >
+            {email}
+            <XIcon
+              className="h-3 w-3 cursor-pointer"
+              onClick={() => handleRemoveRecipient(email)}
+            />
+          </Badge>
+        ))}
+        <div className="flex-1 min-w-[200px]">
+          <AutoComplete
+            items={contacts}
+            onSelectedValueChange={(value) => handleRecipientSelect(value, recipientType)}
+            onSearchValueChange={fetchContacts}
+            placeholder={placeholder}
+            className={cn(INPUT_STYLE, 'w-full')}
+            isLoading={isLoading}
+          />
+        </div>
+      </div>
+    )
+  }
+)
 
 export const RecipientField = observer(({ composeId }: EmailComposerProps) => {
   const compose = composeStore.getCompose(composeId)
   const contacts = contactsStore.contacts
   const isLoading = contactsStore.isLoading
 
-  // Fetch contacts with debounce
+  const [showCC, setShowCC] = useState(false)
+
   const fetchContacts = useCallback(async (searchQuery: string) => {
     try {
       await contactsStore.getContacts(searchQuery)
@@ -23,8 +84,8 @@ export const RecipientField = observer(({ composeId }: EmailComposerProps) => {
   }, [])
 
   const handleRecipientSelect = useCallback(
-    (value: string) => {
-      composeStore.addRecipient(composeId, value, 'to')
+    (value: string, type: RecipientType) => {
+      composeStore.addRecipient(composeId, value, type)
     },
     [composeId]
   )
@@ -38,29 +99,32 @@ export const RecipientField = observer(({ composeId }: EmailComposerProps) => {
 
   if (!compose) return null
 
+  const sharedProps = {
+    composeId,
+    contacts,
+    isLoading,
+    handleRecipientSelect,
+    handleRemoveRecipient,
+    fetchContacts
+  }
+
   return (
-    <div className="inline-flex flex-wrap items-center gap-2 w-full">
-      {Array.from(compose.recipients.entries()).map(([email, type]) => (
-        <Badge
-          key={email}
-          variant="secondary"
-          className="flex-none flex items-center gap-1 px-2 py-1 rounded-sm"
-        >
-          {type !== 'to' && <span className="text-xs text-muted-foreground">{type}:</span>}
-          {email}
-          <XIcon className="h-3 w-3 cursor-pointer" onClick={() => handleRemoveRecipient(email)} />
-        </Badge>
-      ))}
-      <div className="flex-1 min-w-[200px]">
-        <AutoComplete
-          items={contacts}
-          onSelectedValueChange={handleRecipientSelect}
-          onSearchValueChange={fetchContacts}
-          placeholder="recipient@example.com"
-          className={cn(INPUT_STYLE, 'w-full')}
-          isLoading={isLoading}
-        />
-      </div>
+    <div className="flex flex-col relative items-center gap-1">
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setShowCC(!showCC)}
+        className="absolute right-0 top-1 z-50 text-muted-foreground"
+      >
+        CC BCC
+      </Button>
+      <RecipientInput {...sharedProps} recipientType="to" placeholder="recipient@example.com" />
+      {showCC && (
+        <>
+          <RecipientInput {...sharedProps} recipientType="cc" placeholder="cc" />
+          <RecipientInput {...sharedProps} recipientType="bcc" placeholder="bcc" />
+        </>
+      )}
     </div>
   )
 })


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds CC and BCC fields to the email composer with a toggle button and refactors recipient handling in `recipients.tsx`.
> 
>   - **Behavior**:
>     - Adds CC and BCC fields to the email composer in `recipients.tsx`.
>     - Introduces a toggle button to show/hide CC and BCC fields.
>   - **Components**:
>     - Creates `RecipientInput` component to handle different recipient types (`to`, `cc`, `bcc`).
>     - Refactors `RecipientField` to use `RecipientInput` for each recipient type.
>   - **State Management**:
>     - Uses `useState` to manage visibility of CC and BCC fields.
>     - Updates `handleRecipientSelect` to accept `RecipientType` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=usemox%2Fmox&utm_source=github&utm_medium=referral)<sup> for 48634d4a47649fd32774f73e037d66663d2e6423. You can [customize](https://app.ellipsis.dev/usemox/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->